### PR TITLE
use ros package key for libsdformat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(build_catkin OR "${CATKIN_BUILD_BINARY_PACKAGE}")
     LIBRARIES 
     ${target}
     CATKIN_DEPENDS
-    libsdformat2
+    sdformat
   )
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -18,9 +18,9 @@
   <build_depend>choreonoid_ros</build_depend>
 	<build_depend>boost</build_depend>
 	<build_depend>eigen</build_depend>
-  <build_depend>libsdformat2-dev</build_depend>
+  <build_depend>sdformat</build_depend>
 
   <run_depend>choreonoid_ros</run_depend>
-  <run_depend>libsdformat2</run_depend>
+  <run_depend>sdformat</run_depend>
 
 </package>


### PR DESCRIPTION
たびたびすいません。
ROSで使うパッケージ名がdebianのパッケージ名と一致していなかったのでROS側に合わせました。