### PR TITLE
Choreonoid のリファクタリングへの追従を実施しました

### DIFF
--- a/SDFBodyLoader.cpp
+++ b/SDFBodyLoader.cpp
@@ -11,6 +11,8 @@
 #include <cnoid/STLSceneLoader>
 #include <map>
 #include <list>
+#include <cnoid/SceneGraph>
+#include <cnoid/SceneShape>
 #include <cnoid/DaeParser>
 #include <cnoid/MeshGenerator>
 #include <cnoid/NullOut>


### PR DESCRIPTION
2015/12 初旬に実施された Choreonoid 本体のリファクタリングにより、当該プラグインがビルド出来ない状態であった為、修正を実施しました。