### PR TITLE
trivial fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(build_catkin OR "${CATKIN_BUILD_BINARY_PACKAGE}")
   set(ENABLE_INSTALL_RPATH ON CACHE BOOL "Enable RPATH setting for installed binary files" FORCE)
   set(ENV{PKG_CONFIG_PATH} $ENV{PKG_CONFIG_PATH}:${CATKIN_DEVEL_PREFIX}/lib/pkgconfig)
 
-	find_package(catkin REQUIRED COMPONENTS 
+  find_package(catkin REQUIRED COMPONENTS
     choreonoid_ros
   )
 

--- a/SDFLoaderPseudoGazeboColor.cpp
+++ b/SDFLoaderPseudoGazeboColor.cpp
@@ -18,8 +18,8 @@ SDFLoaderPseudoGazeboColorInfo::SDFLoaderPseudoGazeboColorInfo()
     material = new SgMaterial;
 
     /*
-     * setting the Ogre3D's default value
-     * see http://www.ogre3d.org/docs/manual/manual_16.html
+       setting the Ogre3D's default value
+       see http://www.ogre3d.org/docs/manual/manual_16.html
      */
     v << 1.0, 1.0, 1.0;
     material->setDiffuseColor(v);

--- a/SDFLoaderPseudoGazeboColor.h
+++ b/SDFLoaderPseudoGazeboColor.h
@@ -12,16 +12,16 @@
 
 namespace cnoid {
 
-/*!
+/**
  */
 class CNOID_EXPORT SDFLoaderPseudoGazeboColorInfo
 {
 public:
-    /*!
+    /**
      */
     SDFLoaderPseudoGazeboColorInfo();
 
-    /*!
+    /**
      */
     ~SDFLoaderPseudoGazeboColorInfo();
 
@@ -32,20 +32,20 @@ public:
     SgMaterialPtr material;
 };
 
-/*!
+/**
  */
 class CNOID_EXPORT SDFLoaderPseudoGazeboColor
 {
 public:
-    /*!
+    /**
      */
     SDFLoaderPseudoGazeboColor();
 
-    /*!
+    /**
      */
     ~SDFLoaderPseudoGazeboColor();
 
-    /*!
+    /**
      */
     SDFLoaderPseudoGazeboColorInfo* get(std::string name);
 


### PR DESCRIPTION
- メッシュデータが見つからない場合、Choreonoid のメッセージビューへ警告を出力するようにしました。
- SDFBodyLoad::load において、呼び出し元で実行される初期化 (body->clearDevices(), body->clearExtraJoints()) を削除しました。
- ジョイント種別の確認において、Choreonoid が用意している isXXXJoint メソッドを使用するようにしました。
- processMeshes メソッドの名前を processShapes へ変更しました。
- コメントスタイルを Choreonoid のスタイルに合わせました。
- CMakeLists.txt のインデントを修正しました。