### PR TITLE
temprary disable transparency (atlas model becomes fully transparent …

### DIFF
--- a/SDFBodyLoader.cpp
+++ b/SDFBodyLoader.cpp
@@ -844,11 +844,11 @@ void SDFBodyLoaderImpl::loadMaterials(const std::string& resource_path,
                 aiColor3D clr;
                 amat->Get(AI_MATKEY_COLOR_EMISSIVE, clr);
                 material->setEmissiveColor(Vector3f(clr.r, clr.g, clr.b));
+            /*
             } else if (propKey == "$clr.transparent") {
                 aiColor3D clr;
                 amat->Get(AI_MATKEY_COLOR_TRANSPARENT, clr);
                 material->setTransparency((clr.r + clr.g + clr.b) / 3.0f);
-            /*
             } else if (propKey == "$mat.opacity") {
                 float o;
                 amat->Get(AI_MATKEY_OPACITY, o);


### PR DESCRIPTION
…if enabled)

透明色を有効にするとATLASが全て透明になってしまうようなので一時的に無効にしました。